### PR TITLE
v0.1.0: deploy a lib version to npm

### DIFF
--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -1,0 +1,31 @@
+name: Publish to NPM
+
+on:
+  push:
+    tags:
+      - 'v*' # Gatilho ao criar tags como v1.0.0, v2.0.1, etc.
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 22
+        registry-url: https://registry.npmjs.org/
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build the project
+      run: npm run build
+
+    - name: Publish to NPM
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish --access public

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Publish to NPM
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 22
+        registry-url: https://registry.npmjs.org/
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build the project
+      run: npm run test


### PR DESCRIPTION
This workflow will be run when a tag is generated:

```sh
git tag v1.0.0
git push origin v1.0.0
```